### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,29 @@
-# List Switch
-This OctoberCMS plugin add the possibility to create buttons in backend lists that toggle a model property.
-That allow you to create a publish / unpublish button on the lists backend (see bellow for demo).
+# About
+OctoberCMS plugin to add a toggleable switch as a column type to the backend.
 
 ## Usage
-For add this feature to a list, you just need to set the type `inetis-list-switch` in the `columns.yaml` field of your model.
 
-For an advanced usage, see example below :
+To add a switch column to a list; set the `type` of the column to `inetis-list-switch`. 
+
+Example:
 ```yaml
-your_field:
+your_column:
     label: 'Your Label'
-    type: inetis-list-switch # define the type "inetis-list-switch" for create a button
-
-    icon: true # If true replace Yes/No text by ✓/✗ icons (default: true)
-
-    # With the two following params, you can override 
-    # the default title displayed on the button hover 
-    # You can use translation strings
-    titleTrue: 'Unpublish item' # by default : Click to switch to No
-    titleFalse: 'Publish item' # by default : Click to switch to Yes
+    # Define the type as "inetis-list-switch" to enable this functionality
+    type: inetis-list-switch
     
-    # For override the text of the button
-    # the default title displayed on the button hover
-    # You can use translation strings
-    textTrue: 'Published' # by default : Yes
-    textFalse: 'Unpublished' # by default : No
+    # Whether to use ✓/✗ icons to replace the Yes/No text (default: true)
+    icon: true
+   
+    # Overrides the title displayed on hover over the column
+    titleTrue: 'Unpublish item' # (default: 'inetis.listswitch::lang.inetis.listswitch.title_true')
+    titleFalse: 'Publish item' # (default: 'inetis.listswitch::lang.inetis.listswitch.title_false')
+    
+    # Overrides the text displayed on the button
+    textTrue: 'Published' # (default: 'inetis.listswitch::lang.inetis.listswitch.text_true')
+    textFalse: 'Unpublished' #(default: 'inetis.listswitch::lang.inetis.listswitch.text_false')
 ```
+
 
 ## Demo
 *Default behavior*  


### PR DESCRIPTION
Here are the changes as requested by @pvullioud.

Repo description can be changed to
OctoberCMS plugin to add a toggleable switch as a column type to the backend.